### PR TITLE
fix: add missing setuptools requirement for macOS with uv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -174,3 +174,4 @@ websocket-client==1.7.0
 widgetsnbextension==4.0.10
 zipp==3.18.0
 jupyterquiz==2.8.*
+setuptools<78


### PR DESCRIPTION
Adding a upper constraint on setuptools on the one hand installs it and also makes sure the version includes pkg_resources which seems to be needed by other packages. Later versions of setuptools don't have pkg_resources included anymore. If newer versions of setuptools need to be installed, the installation of pkg_resources by itself should also fix the problem.